### PR TITLE
import source files instead of cjs output

### DIFF
--- a/packages/nlmaps-geolocator/package.json
+++ b/packages/nlmaps-geolocator/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.10",
   "description": "",
   "main": "build/nlmaps-geolocator.cjs.js",
-  "module": "build/nlmaps-geolocator.es.js",
+  "module": "src/index.js",
   "scripts": {
     "test": "node test/test.js",
     "build": "rollup -c config/rollup.cjs.js && rollup -c config/rollup.es.js && rollup -c config/rollup.iife.js && cp build/nlmaps-geolocator.iife.js ../../dist/",

--- a/packages/nlmaps-googlemaps/package.json
+++ b/packages/nlmaps-googlemaps/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.12",
   "description": "",
   "main": "build/nlmaps-googlemaps.cjs.js",
-  "module": "build/nlmaps-googlemaps.es.js",
+  "module": "src/index.js",
   "scripts": {
     "test": "node test/test.js",
     "build": "rollup -c config/rollup.cjs.js && rollup -c config/rollup.es.js &&  rollup -c config/rollup.iife.js && cp build/nlmaps-googlemaps.iife.js ../../dist/",

--- a/packages/nlmaps-leaflet/package.json
+++ b/packages/nlmaps-leaflet/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.16",
   "description": "",
   "main": "build/nlmaps-leaflet.cjs.js",
-  "module": "build/nlmaps-leaflet.es.js",
+  "module": "src/index.js",
   "scripts": {
     "test": "node test/test.js",
     "build": "rollup -c config/rollup.cjs.js && rollup -c config/rollup.es.js && rollup -c config/rollup.iife.js && cp build/nlmaps-leaflet.iife.js ../../dist/",

--- a/packages/nlmaps-openlayers/package.json
+++ b/packages/nlmaps-openlayers/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.14",
   "description": "",
   "main": "build/nlmaps-openlayers.cjs.js",
-  "module": "build/nlmaps-openlayers.es.js",
+  "module": "src/index.js",
   "scripts": {
     "test": "node test/test.js",
     "build": "rollup -c config/rollup.cjs.js && rollup -c config/rollup.es.js && rollup -c config/rollup.iife.js && cp build/nlmaps-openlayers.iife.js ../../dist/",

--- a/packages/nlmaps/src/index.js
+++ b/packages/nlmaps/src/index.js
@@ -4,21 +4,21 @@ import { bgLayer as bgL,
          markerLayer as markerL,
          getMapCenter as centerL,
          geocoderControl as geocoderL,
-         geoLocatorControl as glL } from '../../nlmaps-leaflet/build/nlmaps-leaflet.cjs.js';
+         geoLocatorControl as glL } from '../../nlmaps-leaflet';
 
 import { bgLayer as bgOL,
          overlayLayer as overlayOL,
          markerLayer as markerOL,
          getMapCenter as centerOL,
          geocoderControl as geocoderOL,
-         geoLocatorControl as glO } from '../../nlmaps-openlayers/build/nlmaps-openlayers.cjs.js';
+         geoLocatorControl as glO } from '../../nlmaps-openlayers';
 
 import { bgLayer as bgGM,
          overlayLayer as overlayGM,
          markerLayer as markerGM,
          getMapCenter as centerGM,
          geocoderControl as geocoderGM,
-         geoLocatorControl as glG } from '../../nlmaps-googlemaps/build/nlmaps-googlemaps.cjs.js';
+         geoLocatorControl as glG } from '../../nlmaps-googlemaps';
 
 // import { bgLayer as bgL, geoLocatorControl as glL } from 'nlmaps-leaflet';
 


### PR DESCRIPTION
It works to import the source files (ES2015) of the subpackages directly. At least on my machine. I can't remember why we were importing the cjs builds.

If the cjs import is no longer required, this means that the extra step in building is no longer required: first building the subpackages, then main nlmaps package.