### PR TITLE
use source files for module field

### DIFF
--- a/packages/nlmaps-geolocator/package.json
+++ b/packages/nlmaps-geolocator/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.17",
   "description": "",
   "main": "build/nlmaps-geolocator.cjs.js",
-  "module": "build/nlmaps-geolocator.es.js",
+  "module": "src/index.js",
   "scripts": {
     "test": "node test/test.js",
     "build": "rollup -c config/rollup.cjs.js && rollup -c config/rollup.es.js && rollup -c config/rollup.iife.js && cp build/nlmaps-geolocator.iife.js ../../dist/",

--- a/packages/nlmaps-googlemaps/package.json
+++ b/packages/nlmaps-googlemaps/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.17",
   "description": "",
   "main": "build/nlmaps-googlemaps.cjs.js",
-  "module": "build/nlmaps-googlemaps.es.js",
+  "module": "src/index.js",
   "scripts": {
     "test": "node test/test.js",
     "build": "rollup -c config/rollup.cjs.js && rollup -c config/rollup.es.js &&  rollup -c config/rollup.iife.js && cp build/nlmaps-googlemaps.iife.js ../../dist/",

--- a/packages/nlmaps-openlayers/package.json
+++ b/packages/nlmaps-openlayers/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.17",
   "description": "",
   "main": "build/nlmaps-openlayers.cjs.js",
-  "module": "build/nlmaps-openlayers.es.js",
+  "module": "src/index.js",
   "scripts": {
     "test": "node test/test.js",
     "build": "rollup -c config/rollup.cjs.js && rollup -c config/rollup.es.js && rollup -c config/rollup.iife.js && cp build/nlmaps-openlayers.iife.js ../../dist/",

--- a/packages/nlmaps/src/index.js
+++ b/packages/nlmaps/src/index.js
@@ -12,14 +12,14 @@ import { bgLayer as bgOL,
          markerLayer as markerOL,
          getMapCenter as centerOL,
          geocoderControl as geocoderOL,
-         geoLocatorControl as glO } from '../../nlmaps-openlayers/build/nlmaps-openlayers.cjs.js';
+         geoLocatorControl as glO } from '../../nlmaps-openlayers';
 
 import { bgLayer as bgGM,
          overlayLayer as overlayGM,
          markerLayer as markerGM,
          getMapCenter as centerGM,
          geocoderControl as geocoderGM,
-         geoLocatorControl as glG } from '../../nlmaps-googlemaps/build/nlmaps-googlemaps.cjs.js';
+         geoLocatorControl as glG } from '../../nlmaps-googlemaps';
 
 // import { bgLayer as bgL, geoLocatorControl as glL } from 'nlmaps-leaflet';
 


### PR DESCRIPTION
this enables direct build of nlmaps including all subpackages, without having to do a two-step build. i.e. no longer necessary to do

    node scripts/build -p leaflet,googlemaps,openlayers,geolocator

before doing

    node scripts/build -p nlmaps

You can now just do

    node scripts/build

and all packages will be built correctly and fully.